### PR TITLE
Feature: Add the mass hierarchy to the oscillation parameters

### DIFF
--- a/anoa-chain.sh
+++ b/anoa-chain.sh
@@ -1,0 +1,390 @@
+#!/bin/bash
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=35GB
+#SBATCH --time=24:00:00
+#
+#  To use a GPU (you should if one is available), submit using
+#
+#  sbatch --gres=gpu anoa-chain.sh
+#
+#  or, modify the SBATCH line
+#
+#   #SBATCH --gres=gpu
+#
+
+uname -a
+date
+
+# Run an ANOA fit with GUNDAM.  This should be run in the directory where
+# the output belongs.  This is configured for GPUs by default, so you may
+# need to change the #SBATCH lines above.
+#
+# Environment variables that the control behavior
+# 
+# GUNDAM_CONFIG    -- Set the config file base directory
+# GUNDAM_NAME      -- Set the base name for the job (default: "job")
+# GUNDAM_OPTIONS   -- Command line options for GUNDAM 
+# GUNDAM_OVERRIDES -- Override files for GUNDAM
+# GUNDAM_INSTALL   -- The installation location for GUNDAM
+# GUNDAM_PATH      -- Search path for GUNDAM when GUNDAM_INSTALL missing
+# OA_INPUT_FOLDER  -- The input file location
+# GUNDAM_INPUTS    -- Search path for input files when OA_INPUT_FOLDER missing
+#
+# Set up from the command line (this overrides the environment
+# variables that control the behavior)
+#
+# -C config   -- The configuration directory to use.
+#
+# -n name     -- The job name.  This is used to construct the output
+#                directory
+#
+# -O override -- Add an override file from the config/overrides directory
+#
+# -o string   -- Add gundam option
+#
+# -G gundam   -- Override the gundam installation (otherwise, search a path)
+#
+# -I inputs   -- Override the inputs location (otherwise, search a path)
+#
+# -N          -- Start a new MCMC chain.
+
+usage () {
+    cat <<EOF
+USAGE:
+    $(basename $0) [-C config] [-n name] [-O override ] [-o gundam_option] \
+                [-G gundam_installation] [-I inputs] [-N]         
+
+    Run an GUNDAM MCMC chain.  This is mainly intended to be used to
+    run a batch job, but can be run interactively.  Most of the time,
+    you only want to set the job "name", the "override" files, and
+    possibly "gundam_option" values to pass to GUNDAM.
+
+OPTIONS:
+
+     -C config   -- Set the top level directory for the configuration.
+                    This directory should contain the config_DUNE.yaml file.
+
+     -n name     -- The job name.  This is used to construct the output
+                    directory name.  The output directory is created as a
+                    sub-directory of where this command is run.
+
+     -O override -- Add an override file from the config/overrides directory.
+                    Check the GUNDAM documentation for details on how to use
+                    an override file.  This adds a --override-files <override>
+                    option to the gundamFitter command line
+
+     -o string   -- Add gundam option.  The string is directly copied to the
+                    gundamFitter command line.
+
+     -G gundam   -- Override the gundam installation location (otherwise,
+                    a default search path is used).  The installation location
+                    must contain the gundam setup.sh script.
+
+     -I inputs   -- Override the inputs location (otherwise, a default
+                    search a path is used)
+
+     -N          -- Start a new MCMC chain.
+
+EOF
+}
+
+OPTIND=1
+while getopts ":C:n:O:o:N" OPTVAL; do
+    case "${OPTVAL}" in
+        C)
+            GUNDAM_CONFIG=${OPTARG}
+        ;;
+        n)
+            GUNDAM_NAME=${OPTARG}
+        ;;
+        O)
+            GUNDAM_OVERRIDES+=":${OPTARG}"
+        ;;
+        o)
+            GUNDAM_OPTIONS+=" ${OPTARG}"
+            ;;
+        G)
+            GUNDAM_INSTALL="${OPTARG}"
+            ;;
+        I)
+            OA_INPUT_FOLDER="${OPTARG}"
+            ;;
+        N)
+            NEWCHAIN=" -N "
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# If no override files are provided, then add one to start the MCMC.
+# If overrides are provided by the command line (or environment), then
+# an MCMC config will need to be provided, or strange things will
+# happen.
+${GUNDAM_OVERRIDES:="configMcmc.yaml"}
+
+##############################################################
+# Adjust this section for your local machine.  These need to be
+# absolute paths accessible from the job directory.
+##############################################################
+
+##############################################################
+# Absolute path to the config file to be used.  The default should be
+# edited locally
+if [ ! -n "${GUNDAM_CONFIG}" ]; then
+    GUNDAM_CONFIG=/home/mcgrew/work/dune/software/OscAna/gudi-anoa-sen25a/devel
+fi
+CONFIG_FILE=${GUNDAM_CONFIG}/config_DUNE.yaml
+
+##############################################################
+# Define the override files to use (if any)
+CONFIG_OVERRIDE=""
+if [ -n "${GUNDAM_OVERRIDES}" ]; then
+    for i in ${GUNDAM_OVERRIDES//:/ }; do
+        _overrideFile_=${GUNDAM_CONFIG}/overrides/${i}
+        if [ ! -f ${_overrideFile_} ]; then
+            echo OVERRIDE FILE NOT FOUND: ${i}
+            echo file must be in ${GUNDAM_CONFIG}/overrides
+            exit 1
+        fi
+        echo OVERRIDE FILE: ${_overrideFile_}
+        CONFIG_OVERRIDE+=" --override-files ${_overrideFile_}"
+    done
+fi
+
+##############################################################
+# Choose the version of GUNDAM to be running.  GUNDAM should usually
+# be installed in a sub-directory named after the release
+# (e.g. main. rel-2.0.0, lts-1.8.8, etc).  GUNDAM should have been
+# installed using "gundam-build" and will be placed in a machine
+# dependent directory.  The target is the machine type that GUNDAM was
+# compiled for.  The gundam setup.sh file is created when GUNDAM is
+# compiled and is installed at
+# ${GUNDAM_ROOT}/${GUNDAM_RELEASE}/${GUNDAM_TARGET}/setup.sh
+if [ ! -n "${GUNDAM_INSTALL}" ]; then
+    if [ ! -n "${GUNDAM_PATH}" ]; then
+        # Add a path to try, otherwise the path comes from the environment
+        GUNDAM_PATH+=":$(realpath ${PWD})"
+        GUNDAM_PATH+=":${HOME}/work/projects/gundam/devel"
+        # GUNDAM_PATH+=":${HOME}/work/projects/gundam/main"
+        # GUNDAM_PATH+=":${HOME}/work/projects/gundam/lts_1.8.x"
+    fi
+    echo Find GUNDAM implementation
+    for i in ${GUNDAM_PATH//:/ }; do
+        echo LOOK FOR GUNDAM: ${i}
+        for f in $(find ${i} -wholename "*/bin/gundamFitter"); do
+            if [ -x ${f} ]; then
+                echo FOUND: ${f}
+                GUNDAM_INSTALL=$(dirname $(dirname ${f}))
+                break 2;
+            fi
+        done
+    done
+fi
+
+##############################################################
+# Absolute path of the simulation input files.  This is usually the
+# top of the inputs directory hierarchy, but for ATM, it points to
+# the directory with the actual files.
+##############################################################
+export OA_INPUT_FOLDER
+
+## Check some "well known" locations for the input files
+if [ ! -n "${OA_INPUT_FOLDER}" ]; then
+    if [ ! -n "${GUNDAM_INPUTS}" ]; then
+        GUNDAM_INPUTS=":/gpfs/scratch/uyevarouskay/atm/gundam_files_fin_v12"
+        GUNDAM_INPUTS+=":/pnfs/dune/persistent/users/weishi/OA-inputs/atm_reprocessed_v2"
+        GUNDAM_INPUTS+=":/storage/shared/DUNE/OA-inputs/atm/gudi-inputs/v3"
+        GUNDAM_INPUTS+=":/home/mcgrew/data/dune/OA-inputs/atm/gudi-inputs/v3"
+    fi
+    for i in ${GUNDAM_INPUTS//:/ }; do
+        echo LOOK FOR INPUTS: ${i}
+        if [ -d "${i}" ]; then
+            OA_INPUT_FOLDER=${i}
+            break;
+        fi
+    done
+fi
+
+if [ ! -d ${OA_INPUT_FOLDER} ]; then
+    echo MISSING INPUT FOLDER
+    echo Not found: ${OA_INPUT_FOLDER}
+    exit 1
+fi
+
+##############################################################
+# Absolute path to the output directory to be used.
+# OUTPUT_ROOT=/storage/shared/mcgrew/dune/OscAna/
+OUTPUT_ROOT=$(realpath $(pwd))
+
+##############################################################
+# Setup GUNDAM options (but only when not supplied from command line)
+if [ ! -n "${GUNDAM_OPTIONS}" ]; then
+    GUNDAM_OPTIONS="-t 8"
+    GUNDAM_OPTIONS+=" --asimov"
+    GUNDAM_OPTIONS+=" --kick-mc 0.5"
+    GUNDAM_NAME=${GUNDAM_NAME:="asimov"}
+    # GUNDAM_OPTIONS+=" --gpu"
+    # GUNDAM_OPTIONS+=" --dry-run"
+    # GUNDAM_OPTIONS+=" --cpu"
+    # GUNDAM_OPTIONS+=" --cache-manager off"
+    # GUNDAM_OPTIONS+=" --scan"
+    # GUNDAM_OPTIONS+=" --debug"
+fi
+
+#############################################################
+# Define a possible prefix for the gundamFitter.  This is usually
+# blank, but can be used to run gprofng (for profiling), or gdb (for
+# debugging).  GPROFNG will collect the information into the outout
+# directory.  GDB must be run interactively, so make sure you disable
+# the "tee" that is part of the gundamFitter command.
+PREFIX_COMMAND=""
+# PREFIX_COMMAND="gprofng collect app -o ${OUTPUT_DIR}/gundumFitter.er"
+# PREFIX_COMMAND="gdb --args"
+
+# Check that GUNDAM can be setup.
+if [ -f ${GUNDAM_INSTALL}/setup.sh ]; then
+    source ${GUNDAM_INSTALL}/setup.sh
+else
+    echo GUNDAM INSTALLATION NOT FOUND -- setup.sh is missing
+    echo ${GUNDAM_INSTALL}
+    exit 1
+fi
+
+# Check that GUNDAM was found
+if which gundamFitter > /dev/null; then
+    echo GUNDAM WAS CONFIGURED
+    GUNDAM_FITTER=$(which gundamFitter)
+else
+    echo GUNDAM NOT CONFIGURED
+    exit 1
+fi
+
+# Check that gundamContinue was found
+if which gundamContinue > /dev/null; then
+    echo GUNDAM CONTINUE WAS CONFIGURED
+    GUNDAM_CONTINUE=$(which gundamContinue)
+else
+    echo GUNDAM NOT CONFIGURED
+    exit 1
+fi
+
+
+# Check the the config file is found
+if [ ! -f ${CONFIG_FILE} ]; then
+    ls $(dirname ${CONFIG_FILE})
+    echo Missing config file ${CONFIG_FILE}
+    exit 1
+fi
+
+# Set the job name.  This cannot be read from the command line since
+# the command line is rewritten by slurm.
+if [ ! -n "${GUNDAM_NAME}" ]; then
+    GUNDAM_NAME=job
+fi
+JOB_ID=0000
+if [ ${#SLURM_JOB_ID} -gt 0 ]; then
+    JOB_ID=${SLURM_JOB_ID}
+fi
+if [ ${#SLURM_ARRAY_TASK_ID} -gt 0 ]; then
+    JOB_ID="${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}"
+fi
+
+JOB_BASE="anoa-${GUNDAM_NAME}-chain"
+JOB_NAME="${JOB_BASE}-${JOB_ID}-$(date +%y%m%d-%H%M)"
+JOB_DIR=$(realpath $(pwd))
+
+echo JOB BASE: ${JOB_BASE}
+echo JOB NAME: ${JOB_NAME}
+echo JOB ROOT: ${JOB_DIR}
+echo JOB ID: ${JOB_ID}
+echo CONFIG FILE: ${CONFIG_FILE}
+echo OVERRIDES: ${CONFIG_OVERRIDE}
+echo GUNDAM OPTIONS: ${GUNDAM_OPTIONS}
+echo INPUTS: ${OA_INPUT_FOLDER}
+
+# Make output directory in the "jobs" area.
+OUTPUT_DIR=${OUTPUT_ROOT}/${JOB_BASE}-output
+OUTPUT_LOG=${OUTPUT_DIR}/output_${JOB_NAME}.log
+
+mkdir -p ${OUTPUT_DIR}
+
+###############################################
+# Check if the slurm output can be found, and if it can be linked into
+# the output directory.  If there is a slurm log file, put it in the
+# output directory for safe keeping. Be careful since the file system
+# might not be sync'ed.
+if [ ${#SLURM_JOB_ID} -gt 0 ]; then
+    echo Linking ${SLURM_FILE}
+    SLURM_FILE=${JOB_DIR}/slurm-${JOB_ID}.out
+    # Try a few times to find the file (to let file systems sync)
+    for i in 1 2 3 4 5; do
+        if [ -f ${SLURM_FILE} ]; then
+            break;
+        fi
+        echo Waiting for the slurm file: ${SLURM_FILE}
+        sleep 1;
+    done
+    # Make a hard or soft link between the slurm file and the "safe" location.
+    if [ -f ${SLURM_FILE} ]; then
+        echo Check if slurm file and output directory on on the same device.
+        if [ $(stat -c "%d" ${SLURM_FILE}) == $(stat -c "%d" ${OUTPUT_DIR}) ]; then
+            ln  ${SLURM_FILE} ${OUTPUT_DIR}/slurm-${JOB_ID}.out
+        else
+            ln -s ${SLURM_FILE} ${OUTPUT_DIR}/slurm-${JOB_ID}.out
+        fi
+    else
+        echo Slurm file not found
+    fi
+fi
+
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo Using ${GUNDAM_FITTER}
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# DUNE configs expect to be run in the GUNDAM_CONFIG
+cd ${GUNDAM_CONFIG}
+
+# Try to configure NuOscillator.  The oscillator must be installed in
+# ${GUNDAM_CONFIG}
+export NUOSCILLATOR_ROOT=""
+if [ ${#NUOSCILLATOR_ROOT} == 0 ]; then
+    source ./gundamOscAnaTools/resources/TabulateNuOscillator/build-x86_64/bin/setup.NuOscillator.sh
+else
+    if [ -f ${NUOSCILLATOR_ROOT}/setup.sh ]; then
+        source ${NUOSCILLATOR_ROOT}/bin/setup.NuOscillator.sh
+    fi
+fi
+if [ ${#NUOSCILLATOR_ROOT} -gt 0 ]; then
+    echo NUOSCILLATOR_ROOT: ${NUOSCILLATOR_ROOT}
+else
+    echo NUOSCILLATOR NOT CONFIGURED
+    exit 1
+fi
+
+# Show the GUNDAM command that will be run, and then run!
+which ${GUNDAM_FITTER}
+echo ${GUNDAM_CONTINUE} \
+     ${NEWCHAIN} ${OUTPUT_DIR}/${JOB_BASE}.root -- \
+     ${PREFIX_COMMAND} \
+     ${GUNDAM_FITTER} ${GUNDAM_OPTIONS} \
+     -c ${CONFIG_FILE} ${CONFIG_OVERRIDE} \
+     -O /fitterEngineConfig/minimizerConfig/adaptiveRestore=:INPUT: \
+     -o :OUTPUT:
+
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo START $(date)
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+${GUNDAM_CONTINUE} \
+    ${NEWCHAIN} ${OUTPUT_DIR}/${JOB_BASE}.root -- \
+     ${PREFIX_COMMAND} \
+     ${GUNDAM_FITTER} ${GUNDAM_OPTIONS} \
+     -c ${CONFIG_FILE} ${CONFIG_OVERRIDE} \
+     -O /fitterEngineConfig/minimizerConfig/adaptiveRestore=:INPUT: \
+     -o :OUTPUT: \
+      |& tee ${OUTPUT_LOG}
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo FINISH $(date)
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/anoa-job.sh
+++ b/anoa-job.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=35GB
+#SBATCH --time=12:00:00
+#
+#  To use a GPU (you should if one is available), submit using
+#
+#  sbatch --gres=gpu anoa-chain.sh
+#
+#  or, modify the SBATCH line
+#
+#   #SBATCH --gres=gpu
+#
+
+uname -a
+date
+
+# Run an ANOA fit with GUNDAM.  This should be run in the directory where
+# the output belongs.  This is configured for GPUs by default, so you may
+# need to change the #SBATCH lines above.
+#
+# Environment variables that the control behavior
+# 
+# GUNDAM_CONFIG    -- Set the config file base directory
+# GUNDAM_NAME      -- Set the base name for the job (default: "job")
+# GUNDAM_OPTIONS   -- Command line options for GUNDAM 
+# GUNDAM_OVERRIDES -- Override files for GUNDAM
+# GUNDAM_INSTALL   -- The installation location for GUNDAM
+# GUNDAM_PATH      -- Search path for GUNDAM when GUNDAM_INSTALL missing
+# OA_INPUT_FOLDER  -- The input file location
+# GUNDAM_INPUTS    -- Search path for input files when OA_INPUT_FOLDER missing
+#
+# Set up from the command line (this overrides the environment
+# variables that control the behavior)
+#
+# -C config   -- The configuration directory to use.
+#
+# -n name     -- The job name.  This is used to construct the output
+#                directory
+#
+# -O override -- Add an override file from the config/overrides directory
+#
+# -o string   -- Add gundam option
+#
+# -G gundam   -- Override the gundam installation (otherwise, search a path)
+#
+# -I inputs   -- Override the inputs location (otherwise, search a path)
+#
+# -N          -- Start a new MCMC chain.
+
+usage () {
+    cat <<EOF
+USAGE:
+    $(basename $0) [-C config] [-n name] [-O override ] [-o gundam_option] \
+                [-G gundam_installation] [-I inputs]         
+
+    Run an GUNDAM MCMC chain.  This is mainly intended to be used to
+    run a batch job, but can be run interactively.  Most of the time,
+    you only want to set the job "name", the "override" files, and
+    possibly "gundam_option" values to pass to GUNDAM.
+
+OPTIONS:
+
+     -C config   -- Set the top level directory for the configuration.
+                    This directory should contain the config_DUNE.yaml file.
+
+     -n name     -- The job name.  This is used to construct the output
+                    directory name.  The output directory is created as a
+                    sub-directory of where this command is run.
+
+     -O override -- Add an override file from the config/overrides directory.
+                    Check the GUNDAM documentation for details on how to use
+                    an override file.  This adds a --override-files <override>
+                    option to the gundamFitter command line
+
+     -o string   -- Add gundam option.  The string is directly copied to the
+                    gundamFitter command line.
+
+     -G gundam   -- Override the gundam installation location (otherwise,
+                    a default search path is used).  The installation location
+                    must contain the gundam setup.sh script.
+
+     -I inputs   -- Override the inputs location (otherwise, a default
+                    search a path is used)
+
+
+EOF
+}
+
+OPTIND=1
+while getopts ":C:n:O:o:" OPTVAL; do
+    case "${OPTVAL}" in
+        C)
+            GUNDAM_CONFIG=${OPTARG}
+        ;;
+        n)
+            GUNDAM_NAME=${OPTARG}
+        ;;
+        O)
+            GUNDAM_OVERRIDES+=":${OPTARG}"
+        ;;
+        o)
+            GUNDAM_OPTIONS+=" ${OPTARG}"
+            ;;
+        G)
+            GUNDAM_INSTALL="${OPTARG}"
+            ;;
+        I)
+            OA_INPUT_FOLDER="${OPTARG}"
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+##############################################################
+# Adjust this section for your local machine.  These need to be
+# absolute paths accessible from the job directory.
+##############################################################
+
+##############################################################
+# Absolute path to the config file to be used.  The default should be
+# edited locally
+if [ ! -n "${GUNDAM_CONFIG}" ]; then
+    GUNDAM_CONFIG=/home/mcgrew/work/dune/software/OscAna/gudi-anoa-sen25a/devel
+fi
+CONFIG_FILE=${GUNDAM_CONFIG}/config_DUNE.yaml
+
+##############################################################
+# Define the override files to use (if any)
+CONFIG_OVERRIDE=""
+if [ -n "${GUNDAM_OVERRIDES}" ]; then
+    for i in ${GUNDAM_OVERRIDES//:/ }; do
+        _overrideFile_=${GUNDAM_CONFIG}/overrides/${i}
+        if [ ! -f ${_overrideFile_} ]; then
+            echo OVERRIDE FILE NOT FOUND: ${i}
+            echo file must be in ${GUNDAM_CONFIG}/overrides
+            exit 1
+        fi
+        echo OVERRIDE FILE: ${_overrideFile_}
+        CONFIG_OVERRIDE+=" --override-files ${_overrideFile_}"
+    done
+fi
+
+##############################################################
+# Choose the version of GUNDAM to be running.  GUNDAM should usually
+# be installed in a sub-directory named after the release
+# (e.g. main. rel-2.0.0, lts-1.8.8, etc).  GUNDAM should have been
+# installed using "gundam-build" and will be placed in a machine
+# dependent directory.  The target is the machine type that GUNDAM was
+# compiled for.  The gundam setup.sh file is created when GUNDAM is
+# compiled and is installed at
+# ${GUNDAM_ROOT}/${GUNDAM_RELEASE}/${GUNDAM_TARGET}/setup.sh
+if [ ! -n "${GUNDAM_INSTALL}" ]; then
+    if [ ! -n "${GUNDAM_PATH}" ]; then
+        # Add a path to try, otherwise the path comes from the environment
+        GUNDAM_PATH+=":$(realpath ${PWD})"
+        GUNDAM_PATH+=":${HOME}/work/projects/gundam/devel"
+        GUNDAM_PATH+=":${HOME}/work/projects/gundam/main"
+        GUNDAM_PATH+=":${HOME}/work/projects/gundam/lts_1.8.x"
+    fi
+    echo Find GUNDAM implementation
+    for i in ${GUNDAM_PATH//:/ }; do
+        echo LOOK FOR GUNDAM: ${i}
+        for f in $(find ${i} -wholename "*/bin/gundamFitter"); do
+            if [ -x ${f} ]; then
+                echo FOUND: ${f}
+                GUNDAM_INSTALL=$(dirname $(dirname ${f}))
+                break 2;
+            fi
+        done
+    done
+fi
+
+##############################################################
+# Absolute path of the simulation input files.  This is usually the
+# top of the inputs directory hierarchy, but for ATM, it points to
+# the directory with the actual files.
+##############################################################
+export OA_INPUT_FOLDER
+
+## Check some "well known" locations for the input files
+if [ ! -n "${OA_INPUT_FOLDER}" ]; then
+    if [ ! -n "${GUNDAM_INPUTS}" ]; then
+        GUNDAM_INPUTS=":/gpfs/scratch/uyevarouskay/atm/gundam_files_fin_v12"
+        GUNDAM_INPUTS+=":/pnfs/dune/persistent/users/weishi/OA-inputs/atm_reprocessed_v2"
+        GUNDAM_INPUTS+=":/storage/shared/DUNE/OA-inputs/atm/gudi-inputs/v3"
+        GUNDAM_INPUTS+=":/home/mcgrew/data/dune/OA-inputs/atm/gudi-inputs/v3"
+    fi
+    for i in ${GUNDAM_INPUTS//:/ }; do
+        echo LOOK FOR INPUTS: ${i}
+        if [ -d "${i}" ]; then
+            OA_INPUT_FOLDER=${i}
+            break;
+        fi
+    done
+fi
+
+if [ ! -d ${OA_INPUT_FOLDER} ]; then
+    echo MISSING INPUT FOLDER
+    echo Not found: ${OA_INPUT_FOLDER}
+    exit 1
+fi
+
+##############################################################
+# Absolute path to the output directory to be used.
+# OUTPUT_ROOT=/storage/shared/mcgrew/dune/OscAna/
+OUTPUT_ROOT=$(realpath $(pwd))
+
+##############################################################
+# Setup GUNDAM options (but only when not supplied from command line)
+if [ ! -n "${GUNDAM_OPTIONS}" ]; then
+    GUNDAM_OPTIONS="-t 8"
+    GUNDAM_OPTIONS+=" --asimov"
+    GUNDAM_OPTIONS+=" --kick-mc 0.5"
+    GUNDAM_NAME=${GUNDAM_NAME:="asimov"}
+    # GUNDAM_OPTIONS+=" --gpu"
+    # GUNDAM_OPTIONS+=" --dry-run"
+    # GUNDAM_OPTIONS+=" --cpu"
+    # GUNDAM_OPTIONS+=" --cache-manager off"
+    # GUNDAM_OPTIONS+=" --scan"
+    # GUNDAM_OPTIONS+=" --debug"
+fi
+
+#############################################################
+# Define a possible prefix for the gundamFitter.  This is usually
+# blank, but can be used to run gprofng (for profiling), or gdb (for
+# debugging).  GPROFNG will collect the information into the outout
+# directory.  GDB must be run interactively, so make sure you disable
+# the "tee" that is part of the gundamFitter command.
+PREFIX_COMMAND=""
+# PREFIX_COMMAND="gprofng collect app -o ${OUTPUT_DIR}/gundumFitter.er"
+# PREFIX_COMMAND="gdb --args"
+
+# Check that GUNDAM can be setup.
+if [ -f ${GUNDAM_INSTALL}/setup.sh ]; then
+    source ${GUNDAM_INSTALL}/setup.sh
+else
+    echo GUNDAM INSTALLATION NOT FOUND -- setup.sh is missing
+    echo ${GUNDAM_INSTALL}
+    exit 1
+fi
+
+# Check that GUNDAM was found
+if which gundamFitter > /dev/null; then
+    echo GUNDAM WAS CONFIGURED
+    GUNDAM_FITTER=$(which gundamFitter)
+else
+    echo GUNDAM NOT CONFIGURED
+    exit 1
+fi
+
+# Check the the config file is found
+if [ ! -f ${CONFIG_FILE} ]; then
+    ls $(dirname ${CONFIG_FILE})
+    echo Missing config file ${CONFIG_FILE}
+    exit 1
+fi
+
+# Set the job name.  This cannot be read from the command line since
+# the command line is rewritten by slurm.
+if [ ! -n "${GUNDAM_NAME}" ]; then
+    GUNDAM_NAME=job
+fi
+JOB_ID=0000
+if [ ${#SLURM_JOB_ID} -gt 0 ]; then
+    JOB_ID=${SLURM_JOB_ID}
+fi
+if [ ${#SLURM_ARRAY_TASK_ID} -gt 0 ]; then
+    JOB_ID="${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}"
+fi
+
+JOB_BASE="anoa-${GUNDAM_NAME}"
+JOB_NAME="${JOB_BASE}-${JOB_ID}-$(date +%y%m%d-%H%M)"
+JOB_DIR=$(realpath $(pwd))
+
+echo JOB BASE: ${JOB_BASE}
+echo JOB NAME: ${JOB_NAME}
+echo JOB ROOT: ${JOB_DIR}
+echo JOB ID: ${JOB_ID}
+echo CONFIG FILE: ${CONFIG_FILE}
+echo OVERRIDES: ${CONFIG_OVERRIDE}
+echo GUNDAM OPTIONS: ${GUNDAM_OPTIONS}
+echo INPUTS: ${OA_INPUT_FOLDER}
+
+# Make output directory in the "jobs" area.
+OUTPUT_DIR=${OUTPUT_ROOT}/${JOB_NAME}
+OUTPUT_FILE=${OUTPUT_DIR}/output_${JOB_NAME}.root
+OUTPUT_LOG=${OUTPUT_DIR}/output_${JOB_NAME}.log
+
+mkdir -p ${OUTPUT_DIR}
+
+###############################################
+# Check if the slurm output can be found, and if it can be linked into
+# the output directory.  If there is a slurm log file, put it in the
+# output directory for safe keeping. Be careful since the file system
+# might not be sync'ed.
+if [ ${#SLURM_JOB_ID} -gt 0 ]; then
+    echo Linking ${SLURM_FILE}
+    SLURM_FILE=${JOB_DIR}/slurm-${JOB_ID}.out
+    # Try a few times to find the file (to let file systems sync)
+    for i in 1 2 3 4 5; do
+        if [ -f ${SLURM_FILE} ]; then
+            break;
+        fi
+        echo Waiting for the slurm file: ${SLURM_FILE}
+        sleep 1;
+    done
+    # Make a hard or soft link between the slurm file and the "safe" location.
+    if [ -f ${SLURM_FILE} ]; then
+        echo Check if slurm file and output directory on on the same device.
+        if [ $(stat -c "%d" ${SLURM_FILE}) == $(stat -c "%d" ${OUTPUT_DIR}) ]; then
+            ln  ${SLURM_FILE} ${OUTPUT_DIR}/slurm-${JOB_ID}.out
+        else
+            ln -s ${SLURM_FILE} ${OUTPUT_DIR}/slurm-${JOB_ID}.out
+        fi
+    else
+        echo Slurm file not found
+    fi
+fi
+
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo Using ${GUNDAM_FITTER}
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# DUNE configs expect to be run in the GUNDAM_CONFIG
+cd ${GUNDAM_CONFIG}
+
+# Try to configure NuOscillator.  The oscillator must be installed in
+# ${GUNDAM_CONFIG}
+export NUOSCILLATOR_ROOT=""
+if [ ${#NUOSCILLATOR_ROOT} == 0 ]; then
+    source ./gundamOscAnaTools/resources/TabulateNuOscillator/build-x86_64/bin/setup.NuOscillator.sh
+else
+    if [ -f ${NUOSCILLATOR_ROOT}/setup.sh ]; then
+        source ${NUOSCILLATOR_ROOT}/bin/setup.NuOscillator.sh
+    fi
+fi
+if [ ${#NUOSCILLATOR_ROOT} -gt 0 ]; then
+    echo NUOSCILLATOR_ROOT: ${NUOSCILLATOR_ROOT}
+else
+    echo NUOSCILLATOR NOT CONFIGURED
+    exit 1
+fi
+
+echo which ${GUNDAM_FITTER}
+echo ${PREFIX_COMMAND} \
+     ${GUNDAM_FITTER} ${GUNDAM_OPTIONS} \
+     -c ${CONFIG_FILE} ${CONFIG_OVERRIDE} \
+     -o ${OUTPUT_FILE}
+
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo START $(date)
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+time ${PREFIX_COMMAND} ${GUNDAM_FITTER} ${GUNDAM_OPTIONS} \
+     -c ${CONFIG_FILE} ${CONFIG_OVERRIDE} \
+     -o ${OUTPUT_FILE} \
+      |& tee ${OUTPUT_LOG}
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+echo FINISH $(date)
+echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/inputs/parameters/configParSet.yaml
+++ b/inputs/parameters/configParSet.yaml
@@ -58,11 +58,11 @@
       isEnabled: true
       priorValue: -2.233      # PDG 2025 value: 3.74       # 1.19 pi
       priorType: Flat
-      parameterStepSize: 0.5
-      # Set a mirror range since dCP is a truly cyclic parameter.
-      mirrorRange: [ -3.14159265359, 3.14159265359 ]
-      # Better for mirroring since only one bound is irrational
-      # mirrorRange: [ 0.0, 6.28318530718 ]
+      parameterStepSize: 0.1
+      # Possible mirror range, but dCP is a truly cyclic parameter, and
+      # mirroring can bias the posterior for Bayesian analysis (-pi and pi
+      # should be adjacent, but are not with mirroring).
+      # mirrorRange: [ -3.14159265359, 3.14159265359 ]
 
     - name: "PMNS_SIGN_MASS_SQUARED_32"
       isEnabled: true

--- a/inputs/parameters/configParSet.yaml
+++ b/inputs/parameters/configParSet.yaml
@@ -17,51 +17,56 @@
 
     - name: "PMNS_SIN_SQUARED_12"
       isEnabled: true
-      priorValue: 0.303       # PDG 2025 value: 0.307
+      priorValue: 0.303       # PDG 2025 value: 0.307 +/- 0.012
       priorType: Flat
-      parameterStepSize: 0.03
-      parameterLimits: [ 0, 1.0 ]
+      parameterStepSize: 0.01
+      # parameterLimits: [ 0.271, 0.343]  # 3 sigma around PDG.
 
     - name: "PMNS_SIN_SQUARED_13"
       isEnabled: true
-      priorValue: 0.02225     # PDG 2025 value: 0.0219
+      priorValue: 0.02225     # PDG 2025 value: 0.0219 +/- 0.0006
       priorType: Flat
       parameterStepSize: 0.01
-      parameterLimits: [ 0, 0.1 ]
+      # parameterLimits: [ 0.020, 0.0240 ]  # 3 sigma around PDG
 
     - name: "PMNS_SIN_SQUARED_23"
       isEnabled: true
       priorValue: 0.451       # PDG 2025 value: 0.558
       priorType: Flat
       parameterStepSize: 0.04
-      parameterLimits: [ 0, 1.0 ]
+      parameterLimits: [ 0.0, 1.0 ]
 
     - name: "PMNS_DELTA_MASS_SQUARED_21"
       isEnabled: true
-      priorValue: 7.41E-5     # PDG 2025 value: 7.53E-5
+      priorValue: 7.41E-5     # PDG 2025 value: 7.53E-5 +/- 0.19E-5
       priorType: Flat
       parameterStepSize: 7.0e-6
+      # parameterLimits: [ 6.96E-5, 8.10E-5 ]
 
     - name: "PMNS_DELTA_MASS_SQUARED_32"
       isEnabled: true
       priorValue: 2.51E-3     # PDG 2025 value: 0.002455
       priorType: Flat
       parameterStepSize: 2.0E-4
+      parameterLimits: [ 0.0, 1.0 ]
 
     - name: "PMNS_DELTA_CP"
       isEnabled: true
       priorValue: -2.233      # PDG 2025 value: 3.74       # 1.19 pi
       priorType: Flat
-      parameterStepSize: 1.0
-      parameterLimits: [ -3.1416, 3.1416 ]
+      parameterStepSize: 0.5
+      # Set a mirror range since dCP is a truly cyclic parameter.
+      mirrorRange: [ -3.14159265359, 3.14159265359 ]
+      # Better for mirroring since only one bound is irrational
+      # mirrorRange: [ 0.0, 6.28318530718 ]
 
     - name: "PMNS_SIGN_MASS_SQUARED_32"
       isEnabled: true
       isFixed: true
-      priorValue: 1.0         # PDG 2025 value: inverted
+      priorValue: 0.5         # PDG 2025 value: inverted
       priorType: Flat
-      parameterStepSize: 1.0
-      parameterLimits: [ -2.0, 2.0 ]
+      parameterStepSize: 0.5
+      parameterLimits: [ -1.0, 1.0 ]
 
   dialSetDefinitions:
 

--- a/inputs/parameters/configParSet.yaml
+++ b/inputs/parameters/configParSet.yaml
@@ -20,6 +20,8 @@
       priorValue: 0.303       # PDG 2025 value: 0.307 +/- 0.012
       priorType: Flat
       parameterStepSize: 0.01
+      parameterLimits: [ 0.0, 1.0]
+      physicalLimits: [ 0.0, 1.0]
       # parameterLimits: [ 0.271, 0.343]  # 3 sigma around PDG.
 
     - name: "PMNS_SIN_SQUARED_13"
@@ -27,6 +29,8 @@
       priorValue: 0.02225     # PDG 2025 value: 0.0219 +/- 0.0006
       priorType: Flat
       parameterStepSize: 0.01
+      parameterLimits: [ 0.0, 1.0 ]
+      physicalLimits: [ 0.0, 1.0]
       # parameterLimits: [ 0.020, 0.0240 ]  # 3 sigma around PDG
 
     - name: "PMNS_SIN_SQUARED_23"
@@ -35,20 +39,20 @@
       priorType: Flat
       parameterStepSize: 0.04
       parameterLimits: [ 0.0, 1.0 ]
+      physicalLimits: [ 0.0, 1.0]
 
     - name: "PMNS_DELTA_MASS_SQUARED_21"
       isEnabled: true
       priorValue: 7.41E-5     # PDG 2025 value: 7.53E-5 +/- 0.19E-5
       priorType: Flat
       parameterStepSize: 7.0e-6
-      # parameterLimits: [ 6.96E-5, 8.10E-5 ]
+      # parameterLimits: [ 6.96E-5, 8.10E-5 ]    # 3 sigma around PDG
 
     - name: "PMNS_DELTA_MASS_SQUARED_32"
       isEnabled: true
       priorValue: 2.51E-3     # PDG 2025 value: 0.002455
       priorType: Flat
       parameterStepSize: 2.0E-4
-      parameterLimits: [ 0.0, 1.0 ]
 
     - name: "PMNS_DELTA_CP"
       isEnabled: true

--- a/inputs/parameters/configParSet.yaml
+++ b/inputs/parameters/configParSet.yaml
@@ -55,6 +55,14 @@
       parameterStepSize: 1.0
       parameterLimits: [ -3.1416, 3.1416 ]
 
+    - name: "PMNS_SIGN_MASS_SQUARED_32"
+      isEnabled: true
+      isFixed: true
+      priorValue: 1.0         # PDG 2025 value: inverted
+      priorType: Flat
+      parameterStepSize: 1.0
+      parameterLimits: [ -2.0, 2.0 ]
+
   dialSetDefinitions:
 
   #######################################################################3
@@ -74,6 +82,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged numu to nue with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -81,7 +90,7 @@
         initArguments:
           - "FLUX_FLAVOR muon"        # muon neutrino flux
           - "INTERACTION_FLAVOR electron"   # electron neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -105,6 +114,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged numu to numu with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -112,7 +122,7 @@
         initArguments:
           - "FLUX_FLAVOR muon"          # muon neutrino flux
           - "INTERACTION_FLAVOR muon"   # muon neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -136,6 +146,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged numu to nutau with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -143,7 +154,7 @@
         initArguments:
           - "FLUX_FLAVOR muon"          # muon neutrino flux
           - "INTERACTION_FLAVOR tau"    # tau neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -173,6 +184,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged nue to nue with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -180,7 +192,7 @@
         initArguments:
           - "FLUX_FLAVOR electron"          # electron neutrino flux
           - "INTERACTION_FLAVOR electron"   # electron neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -204,6 +216,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged nue to numu with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -211,7 +224,7 @@
         initArguments:
           - "FLUX_FLAVOR electron"      # electron neutrino flux
           - "INTERACTION_FLAVOR muon"   # muon neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -235,6 +248,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged nue to nutau with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -242,7 +256,7 @@
         initArguments:
           - "FLUX_FLAVOR electron"      # electron neutrino flux
           - "INTERACTION_FLAVOR tau"    # tau neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -272,6 +286,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged numu-bar to nue-bar with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -279,7 +294,7 @@
         initArguments:
           - "FLUX_FLAVOR anti-muon"              # muon anti-neutrino flux
           - "INTERACTION_FLAVOR anti-electron"   # electron anti-neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -303,6 +318,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged numu-bar to numu-bar with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -310,7 +326,7 @@
         initArguments:
           - "FLUX_FLAVOR anti-muon"          # muon anti-neutrino flux
           - "INTERACTION_FLAVOR anti-muon"   # muon anti-neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -334,6 +350,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged numu-bar to nutau-bar with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -341,7 +358,7 @@
         initArguments:
           - "FLUX_FLAVOR anti-muon"          # muon anti-neutrino flux
           - "INTERACTION_FLAVOR anti-tau"    # tau anti-neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -371,6 +388,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged nue-bar to nue-bar with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -378,7 +396,7 @@
         initArguments:
           - "FLUX_FLAVOR anti-electron"          # electron anti-neutrino flux
           - "INTERACTION_FLAVOR anti-electron"   # electron anti-neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -402,6 +420,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged nue-bar to numu-bar with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -409,7 +428,7 @@
         initArguments:
           - "FLUX_FLAVOR anti-electron"      # electron anti-neutrino flux
           - "INTERACTION_FLAVOR anti-muon"   # muon anti-neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"
@@ -433,6 +452,7 @@
         - name: "PMNS_DELTA_MASS_SQUARED_21"
         - name: "PMNS_DELTA_MASS_SQUARED_32"
         - name: "PMNS_DELTA_CP"
+        - name: "PMNS_SIGN_MASS_SQUARED_32"
       tableConfig:
         name: "Kriged nue-bar to nutau-bar with CUDAProb3"  # Must be unique.
         libraryPath: "${NUOSCILLATOR_ROOT}/lib/libTabulatedNuOscillator.so"
@@ -440,7 +460,7 @@
         initArguments:
           - "FLUX_FLAVOR anti-electron"      # electron anti-neutrino flux
           - "INTERACTION_FLAVOR anti-tau"    # tau anti-neutrino
-          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP"
+          - "PARAMETERS SS12,SS13,SS23,DM21,DM32,DCP,SIGN32"
           - "ENERGY_RESOLUTION 0.04"
           - "ZENITH_RESOLUTION 0.0"
           - "PRODUCTION_HEIGHT 20"

--- a/overrides/burninMcmc.yaml
+++ b/overrides/burninMcmc.yaml
@@ -1,0 +1,20 @@
+# A config to get an MCMC chain started.  This runs a job with 1M steps.
+
+fitterEngineConfig:
+
+  minimizerConfig:
+    type: SimpleMcmc
+    algorithm: metropolis
+    proposal: adaptive
+
+    burninCycles: 5
+    burninSteps: 10000
+    saveBurnin: true
+    burninSequence: |
+      for (int chain = 0; chain < gMCMC.Burnin(); ++chain) {
+        std::cout << "Start burn-in chain " << chain << std::endl;
+        gMCMC.FreezeCovariance(false);
+        gMCMC.AcceptanceWindow(100);
+        gMCMC.CovarianceWindow(gMCMC.Steps()+gMCMC.Burnin()*gMCMC.Steps()/2);
+        gMCMC.RunCycle("Burn-in",chain);
+      }

--- a/overrides/configMcmc.yaml
+++ b/overrides/configMcmc.yaml
@@ -1,4 +1,4 @@
-# A config to get an MCMC chain started.  This runs a job with 1M steps.  
+# A config to get an MCMC chain started.  This runs a job with 1M steps.
 
 fitterEngineConfig:
 
@@ -6,10 +6,14 @@ fitterEngineConfig:
     type: SimpleMcmc
     algorithm: metropolis
     proposal: adaptive
+    # Make sure that MinimizerBase doesn't get involved.
     checkParameterValidity: true
+    # The validity that SimpleMcmc needs to check.
+    likelihoodValidity: range,physical,nomirror
+    # No restoration by default.  Usually overridden from the command line
     adaptiveRestore: none
-    
-    cycles: 3
+
+    cycles: 5
     steps: 10000
     acceptanceWindow: 400
     covarianceWindow: 200000
@@ -18,15 +22,4 @@ fitterEngineConfig:
       for (int chain = 0; chain < gMCMC.Cycles(); ++chain) {
         std::cout << "Start chain " << chain << std::endl;
         gMCMC.RunCycle("Chain",chain);
-      }
-
-    burninCycles: 1
-    saveBurnin: true
-    burninSequence: |
-      for (int chain = 0; chain < gMCMC.Burnin(); ++chain) {
-        std::cout << "Start burn-in chain " << chain << std::endl;      
-        gMCMC.FreezeCovariance(false);
-        gMCMC.AcceptanceWindow(100);
-        gMCMC.CovarianceWindow(gMCMC.Steps()+gMCMC.Burnin()*gMCMC.Steps()/2);
-        gMCMC.RunCycle("Burn-in",chain);
       }

--- a/overrides/freeHierarchy.yaml
+++ b/overrides/freeHierarchy.yaml
@@ -1,0 +1,24 @@
+## Apply oscillation parameter values:  Use with
+#
+# --override-files ${CONFIG_DIR}/overrides/nuFitSkOscillationParameters.yaml
+#
+# This sets the oscillation parameters to the NuFit 5.2 SK Atmospheric Fit
+# values
+
+fitterEngineConfig:
+  likelihoodInterfaceConfig:
+    propagatorConfig:
+      parametersManagerConfig:
+        parameterSetList:
+          - name: "Oscillation Parameters"
+
+            parameterDefinitions:
+              - name: "PMNS_SIGN_MASS_SQUARED_32"
+                isFixed: false
+
+                
+                
+
+
+
+                

--- a/overrides/invertedHierarchy.yaml
+++ b/overrides/invertedHierarchy.yaml
@@ -15,7 +15,7 @@ fitterEngineConfig:
             parameterDefinitions:
               - name: "PMNS_SIGN_MASS_SQUARED_32"
                 isFixed: true
-                priorValue: -1.0        # PDG 2025 value: inverted
+                priorValue: -0.5        # PDG 2025 value: inverted
 
                 
                 

--- a/overrides/invertedHierarchy.yaml
+++ b/overrides/invertedHierarchy.yaml
@@ -1,0 +1,25 @@
+## Apply oscillation parameter values:  Use with
+#
+# --override-files ${CONFIG_DIR}/overrides/nuFitSkOscillationParameters.yaml
+#
+# This sets the oscillation parameters to the NuFit 5.2 SK Atmospheric Fit
+# values
+
+fitterEngineConfig:
+  likelihoodInterfaceConfig:
+    propagatorConfig:
+      parametersManagerConfig:
+        parameterSetList:
+          - name: "Oscillation Parameters"
+
+            parameterDefinitions:
+              - name: "PMNS_SIGN_MASS_SQUARED_32"
+                isFixed: true
+                priorValue: -1.0        # PDG 2025 value: inverted
+
+                
+                
+
+
+
+                

--- a/overrides/normalHierarchy.yaml
+++ b/overrides/normalHierarchy.yaml
@@ -15,7 +15,7 @@ fitterEngineConfig:
             parameterDefinitions:
               - name: "PMNS_SIGN_MASS_SQUARED_32"
                 isFixed: true
-                priorValue: 1.0         # PDG 2025 value: inverted
+                priorValue: 0.5         # PDG 2025 value: inverted
 
                 
                 

--- a/overrides/normalHierarchy.yaml
+++ b/overrides/normalHierarchy.yaml
@@ -1,0 +1,25 @@
+## Apply oscillation parameter values:  Use with
+#
+# --override-files ${CONFIG_DIR}/overrides/nuFitSkOscillationParameters.yaml
+#
+# This sets the oscillation parameters to the NuFit 5.2 SK Atmospheric Fit
+# values
+
+fitterEngineConfig:
+  likelihoodInterfaceConfig:
+    propagatorConfig:
+      parametersManagerConfig:
+        parameterSetList:
+          - name: "Oscillation Parameters"
+
+            parameterDefinitions:
+              - name: "PMNS_SIGN_MASS_SQUARED_32"
+                isFixed: true
+                priorValue: 1.0         # PDG 2025 value: inverted
+
+                
+                
+
+
+
+                


### PR DESCRIPTION
Adds a new "dummy" parameter to control the mass hierarchy for dms32.  By default, the value is fixed (and set to normal hierarchy, with little justification).  The parameter is used as `sign(SIGN32)*dms32`, so strictly speaking, it flips the sign of the mass when `SIGN32<0`, but by convention we should always use a positive dms32.  This also removes the bounds from the dCP parameter since it is cyclic, not bounded.

This also adds a couple of extras that don't directly affect the configuration.  
1) Add more general scripts that can be submitted to slurm (`anoa-job.sh` for a fit, and `anoa-chain.sh` to start/continue an MCMC chain).  
2) A small update to how the mcmc overrides are setup.